### PR TITLE
introduce sliding queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/remerge/go-worker_pool
 
 go 1.12
 
-require github.com/remerge/cue v0.0.0-20180404154012-5ce627d813ef
+require (
+	github.com/remerge/cue v0.0.0-20180404154012-5ce627d813ef
+	github.com/stretchr/testify v1.3.0
+)

--- a/sliding_queue.go
+++ b/sliding_queue.go
@@ -1,0 +1,109 @@
+package workerpool
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"sync/atomic"
+)
+
+// SlidingQueue guarantees sequential results processing
+type SlidingQueue struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	lastIndex  int64 // index clock
+	lastCommit int64
+	available  chan int64
+
+	mu            sync.Mutex
+	slotsInFlight map[int64]*slidingQueueSlot
+}
+
+// NewSlidingQueue returns new sliding queue with given capacity
+func NewSlidingQueue(capacity int) (q *SlidingQueue) {
+	q = &SlidingQueue{
+		// lastCommit:    -1,
+		available:     make(chan int64, capacity),
+		slotsInFlight: map[int64]*slidingQueueSlot{},
+	}
+	q.ctx, q.cancel = context.WithCancel(context.Background())
+	for i := 0; i < capacity; i++ {
+		q.addAvailable()
+	}
+	go func() {
+		<-q.ctx.Done()
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		q.evaluateSlots()
+	}()
+	return q
+}
+
+// Close closes SlidingQueue and cancels context of all slots
+func (q *SlidingQueue) Close() error {
+	q.cancel()
+	return nil
+}
+
+func (q *SlidingQueue) Acquire(ctx context.Context, fn func()) (commit func(), err error) {
+	select {
+	case <-q.ctx.Done():
+		return nil, q.ctx.Err()
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case index := <-q.available:
+		q.mu.Lock()
+		q.slotsInFlight[index] = &slidingQueueSlot{
+			commit: fn,
+		}
+		q.mu.Unlock()
+		return func() {
+			q.onCommit(index)
+		}, nil
+	}
+}
+
+func (q *SlidingQueue) addAvailable() {
+	select {
+	case <-q.ctx.Done():
+	case q.available <- atomic.AddInt64(&q.lastIndex, 1):
+	}
+}
+
+func (q *SlidingQueue) onCommit(index int64) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.slotsInFlight[index].done = true
+	q.evaluateSlots()
+	q.addAvailable()
+}
+
+func (q *SlidingQueue) evaluateSlots() {
+	var done []int64
+	for i, slot := range q.slotsInFlight {
+		if slot.done {
+			done = append(done, i)
+		}
+	}
+	sort.Slice(done, func(i, j int) bool {
+		return done[i] < done[j]
+	})
+
+	if len(done) > 0 {
+		for _, i := range done {
+			if i-q.lastCommit > 1 {
+				break
+			}
+			q.slotsInFlight[i].commit()
+			q.lastCommit = i
+			delete(q.slotsInFlight, i)
+		}
+	}
+}
+
+type slidingQueueSlot struct {
+	commit func()
+	done   bool
+}

--- a/sliding_queue_test.go
+++ b/sliding_queue_test.go
@@ -1,0 +1,48 @@
+package workerpool
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlidingQueque_Acquire(t *testing.T) {
+	intSlice := func(n int) []int {
+		s := make([]int, n)
+		for i := 0; i < n; i++ {
+			s[i] = i
+		}
+		return s
+	}
+
+	stopChan := make(chan struct{})
+	var results []int
+	var mu sync.Mutex
+
+	q := NewSlidingQueue(32)
+	for i := 0; i < 100; i++ {
+		cb := func(i int) func() {
+			return func() {
+				mu.Lock()
+				defer mu.Unlock()
+				results = append(results, i)
+				if len(results) == 100 {
+					close(stopChan)
+				}
+			}
+		}
+		commit, err := q.Acquire(context.Background(), cb(i))
+		assert.NoError(t, err)
+		go func(i int, commit func()) {
+			time.Sleep(time.Millisecond * time.Duration(rand.Int63n(100)))
+			commit()
+		}(i, commit)
+	}
+	<-stopChan
+	_ = q.Close()
+	assert.Equal(t, intSlice(100), results)
+}


### PR DESCRIPTION
Solution for “small fuzzy batches” used by GGP. Some flows needs to parallelise data processing regardless of parallelisation of data sources. 

Yep. It’s about Kafka partitions. But Kafka requires consistent offsets saving. SlidingQueue automates this process. Each operation divided to processing and commit function. SQ presumes that processing function is asynchronous and call commit only if processing was successful. The biggest advantage is that SQ always calls commits in order. 

For example we have five messages from partition and want to save them in aerospike. Just save in processing and “ack” in commit. All messages will be saved in parallel and acked in correct order. If fifth message processing is failed only first four messages will be acked and SQ will be automatically closed. 

Of course processing can use worker pools.